### PR TITLE
Handling "one session with only one process"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build directory
+build/
+*.egg-info/

--- a/repeatfs/provenance/io_record.py
+++ b/repeatfs/provenance/io_record.py
@@ -28,7 +28,7 @@ class IORecord:
         """ Get IO for a descriptor and pid """
         with management.lock:
             if descriptor not in cls._lookup:
-                return
+                return {} if pid is None else None
 
             if not pid:
                 return cls._lookup[descriptor]

--- a/repeatfs/provenance/management.py
+++ b/repeatfs/provenance/management.py
@@ -207,9 +207,12 @@ class Management:
             return
 
         pid = self.core.get_pid(pid)
-
+        pids = IORecord.get(descriptor, self)
+        # check for None
+        if pids is None:
+            self.register_open(descriptor, pid=pid, record_file=False)
         # Ensure pid recorded to this descriptor (for descriptors passed to child processes)
-        if pid not in IORecord.get(descriptor, self):
+        elif pid not in pids:
             self.register_open(descriptor, pid=pid, record_file=False)
 
         IORecord.get(descriptor, self, pid=pid).update(IORecord.IO_READ, op_type, io_time=io_time)
@@ -223,9 +226,12 @@ class Management:
             return
 
         pid = self.core.get_pid(pid)
-
+        pids = IORecord.get(descriptor, self)
+        # check for None
+        if pids is None:
+            self.register_open(descriptor, pid=pid, record_file=False)
         # Ensure pid recorded to this descriptor (for descriptors passed to child processes)
-        if pid not in IORecord.get(descriptor, self):
+        elif pid not in pids:
             self.register_open(descriptor, pid=pid, record_file=False)
 
         IORecord.get(descriptor, self, pid=pid).update(IORecord.IO_WRITE, op_type, io_time=io_time)

--- a/repeatfs/provenance/management.py
+++ b/repeatfs/provenance/management.py
@@ -207,12 +207,9 @@ class Management:
             return
 
         pid = self.core.get_pid(pid)
-        pids = IORecord.get(descriptor, self)
-        # check for None
-        if pids is None:
-            self.register_open(descriptor, pid=pid, record_file=False)
+
         # Ensure pid recorded to this descriptor (for descriptors passed to child processes)
-        elif pid not in pids:
+        if pid not in IORecord.get(descriptor, self):
             self.register_open(descriptor, pid=pid, record_file=False)
 
         IORecord.get(descriptor, self, pid=pid).update(IORecord.IO_READ, op_type, io_time=io_time)
@@ -226,12 +223,9 @@ class Management:
             return
 
         pid = self.core.get_pid(pid)
-        pids = IORecord.get(descriptor, self)
-        # check for None
-        if pids is None:
-            self.register_open(descriptor, pid=pid, record_file=False)
+
         # Ensure pid recorded to this descriptor (for descriptors passed to child processes)
-        elif pid not in pids:
+        if pid not in IORecord.get(descriptor, self):
             self.register_open(descriptor, pid=pid, record_file=False)
 
         IORecord.get(descriptor, self, pid=pid).update(IORecord.IO_WRITE, op_type, io_time=io_time)

--- a/repeatfs/provenance/process_record.py
+++ b/repeatfs/provenance/process_record.py
@@ -186,9 +186,9 @@ class ProcessRecord:
             self.exe = os.readlink("/proc/{0}/exe".format(self.pid)) if self.pid > 1 else ""
             # re-direction to the real path
             if self.exe is not None and self.exe!="":
-                if self.management.core.mount == os.path.commonpath([self.exe, self.management.core.mount]):
-                    relative = os.path.relpath(self.exe, self.management.core.mount)
-                    self.exe = os.path.join(self.management.core.root, relative)
+                path=FileEntry.get_paths(self.exe, self.management.core.root, self.management.core.mount)
+                if path is not None and path['abs_real'] is not None:
+                    self.exe=path['abs_real']
             try:
                 self.md5 = self.management._calculate_hash(self.exe)
             except (PermissionError, FileNotFoundError):

--- a/repeatfs/provenance/process_record.py
+++ b/repeatfs/provenance/process_record.py
@@ -34,7 +34,7 @@ class ProcessRecord:
             if pid in cls._lookup:
                 # Update entry
                 process_record = cls._lookup[pid]
-                process_record._update(ignore_pipes)
+                process_record._update(ignore_pipes=ignore_pipes)
             else:
                 # Create and register new entry
                 process_record = ProcessRecord(pid, management, ignore_pipes)

--- a/repeatfs/provenance/process_record.py
+++ b/repeatfs/provenance/process_record.py
@@ -185,9 +185,10 @@ class ProcessRecord:
         try:
             self.exe = os.readlink("/proc/{0}/exe".format(self.pid)) if self.pid > 1 else ""
             # re-direction to the real path
-            if self.management.core.mount == os.path.commonpath([self.exe, self.management.core.mount]):
-                relative = os.path.relpath(self.exe, self.management.core.mount)
-                self.exe = os.path.join(self.management.core.root, relative)
+            if self.exe is not None and self.exe!="":
+                if self.management.core.mount == os.path.commonpath([self.exe, self.management.core.mount]):
+                    relative = os.path.relpath(self.exe, self.management.core.mount)
+                    self.exe = os.path.join(self.management.core.root, relative)
             try:
                 self.md5 = self.management._calculate_hash(self.exe)
             except (PermissionError, FileNotFoundError):

--- a/repeatfs/provenance/process_record.py
+++ b/repeatfs/provenance/process_record.py
@@ -184,6 +184,10 @@ class ProcessRecord:
         # Record executable
         try:
             self.exe = os.readlink("/proc/{0}/exe".format(self.pid)) if self.pid > 1 else ""
+            # re-direction to the real path
+            if self.management.core.mount == os.path.commonpath([self.exe, self.management.core.mount]):
+                relative = os.path.relpath(self.exe, self.management.core.mount)
+                self.exe = os.path.join(self.management.core.root, relative)
             try:
                 self.md5 = self.management._calculate_hash(self.exe)
             except (PermissionError, FileNotFoundError):

--- a/repeatfs/provenance/replication.py
+++ b/repeatfs/provenance/replication.py
@@ -368,6 +368,16 @@ class Replication:
 
                     # Update remaining
                     expand_remain.discard(parent_id)
+                    
+            unexpandable = {
+                pid for pid in expand_remain
+                if not any(
+                    tuple(str(p[k]) for k in ["phost", "parent_start", "parent_pid"]) == pid
+                    for p in self.provenance["process"].values()
+                )
+            }
+            session_children.update(unexpandable)
+            expand_remain -= unexpandable
 
         # Build chains for all session children
         for process_id in session_children:


### PR DESCRIPTION
In the original code, get_session_chains only removes items from expand_remain when a child process of the current session is found (line 370, which is inside the for loop starting at line 355).

However, there is a potential case where a session contains only a single process and does not spawn any child processes. In such cases, the corresponding process in expand_remain is never discarded.

Since the while True loop (starting at line 384) only exits when expand_current becomes empty—which never happens in this case—this results in an infinite loop.

My solution: Add logic to discard processes from expand_remain if they are not expandable (i.e., they have no children), to ensure the loop can eventually terminate.